### PR TITLE
Fix UI hide call in GameRoot

### DIFF
--- a/GameRoot.gd
+++ b/GameRoot.gd
@@ -40,12 +40,12 @@ func _on_left_screen():
 
 
 func _on_enter_screen():
-	#hide UI
-	out_of_screen_feedback.hide
-	#stop timer
-	out_of_screen_feedback_timer.stop()
-	#hide text
-	$HUD/OutOfScreenFeedback/RichTextLabel.hide()
+        #hide UI
+        out_of_screen_feedback.hide()
+        #stop timer
+        out_of_screen_feedback_timer.stop()
+        #hide text
+        $HUD/OutOfScreenFeedback/RichTextLabel.hide()
 
 
 func _on_ship_lured_in(siren):


### PR DESCRIPTION
## Summary
- ensure out-of-screen feedback UI properly hides when entering the screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687588cf8dc08328a1b7fe3904b5c0d4